### PR TITLE
chore: fix npm script for windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite build --watch --mode development",
     "build": "vite build",
-    "format": "prettier --write '**/*.{js,ts,tsx,json}'"
+    "format": "prettier --write \"**/*.{js,ts,tsx,json}\""
   },
   "devDependencies": {
     "@crashmax/prettier-config": "^4.1.0",


### PR DESCRIPTION
Resolves an issue where the npm script was not compatible with Windows because the Windows Command shell doesn't support single quotes.